### PR TITLE
DES-1930: fix toasts when running .net4.0 or higher

### DIFF
--- a/minuet/symphony/Paragon.Plugins.Notifications/WindowInteropHelperUtilities.cs
+++ b/minuet/symphony/Paragon.Plugins.Notifications/WindowInteropHelperUtilities.cs
@@ -23,12 +23,30 @@ namespace Paragon.Plugins.Notifications
                     BindingFlags.NonPublic,
                     null, helper, null);
 
-                typeof (Window).InvokeMember(
-                    "SafeCreateWindow",
-                    BindingFlags.InvokeMethod |
-                    BindingFlags.Instance |
-                    BindingFlags.NonPublic,
-                    null, window, null);
+                try
+                {
+                    // SafeCreateWindow only exists in the .NET 2.0 runtime. If we try to
+                    // invoke this method on the .NET 4.0 runtime it will result in a
+                    // MissingMethodException, see below.
+                    typeof(Window).InvokeMember(
+                        "SafeCreateWindow",
+                        BindingFlags.InvokeMethod |
+                        BindingFlags.Instance |
+                        BindingFlags.NonPublic,
+                        null, window, null);
+                }
+                catch (MissingMethodException)
+                {
+                    // If we ended up here it means we are running on the .NET 4.0 runtime,
+                    // where the method we need to call for the handle was renamed/replaced
+                    // with CreateSourceWindow.
+                    typeof(Window).InvokeMember(
+                        "CreateSourceWindow",
+                        BindingFlags.InvokeMethod |
+                        BindingFlags.Instance |
+                        BindingFlags.NonPublic,
+                        null, window, new object[] { false });
+                }
             }
 
             return helper.Handle;


### PR DESCRIPTION
please review, toast messages were not showing on system with only .net4.0 or higher.  we need minuet to run on any system with .net3.5 or higher.
