### PR TITLE
des-4062: fix persisted notfs overflow

### DIFF
--- a/minuet/symphony/Paragon.Plugins.Notifications/Models/NotificationCollection.cs
+++ b/minuet/symphony/Paragon.Plugins.Notifications/Models/NotificationCollection.cs
@@ -9,7 +9,7 @@ namespace Paragon.Plugins.Notifications.Models
 {
     public class NotificationCollection
     {
-        private const int MaxNotifications = 5;
+        private const int MaxNotifications = 11;
         private readonly ObservableCollection<Notification> collection;
         private readonly TaskScheduler taskScheduler;
 
@@ -36,7 +36,7 @@ namespace Paragon.Plugins.Notifications.Models
             {
                 var activeNotifications = ActiveNotifications();
 
-                if (!activeNotifications.Any())
+                if (activeNotifications.Any())
                 {
                     var firstNonPersistantNotification = activeNotifications.FirstOrDefault(item => !item.IsPersistent);
                     var firstPersistantNotification = activeNotifications.FirstOrDefault(item => item.IsPersistent);


### PR DESCRIPTION
fixes des-4062: persisted notifications were overflowing screen.  change so that if number of notifications is greater than 10 then remove oldest non-persistent notification first then remove persistent notification.  max of 10 shouldn't overflow the screen.
