### PR TITLE
Des 5251

### DIFF
--- a/minuet/symphony/Symphony/Symphony/appbridge.js
+++ b/minuet/symphony/Symphony/Symphony/appbridge.js
@@ -13,6 +13,11 @@ var appbridge = new function () {
      * Public functions.
      * *************************************************/
 
+    // read by client app to determine if symphony logo in header should be shown
+    this.ShowHeaderLogo = function () {
+        return false;
+    }
+
     self.Log = function (message) {
         console.log("[JS]", message);
     };

--- a/minuet/symphony/Symphony/Symphony/appbridge.js
+++ b/minuet/symphony/Symphony/Symphony/appbridge.js
@@ -15,7 +15,7 @@ var appbridge = new function () {
 
     // read by client app to determine if symphony logo in header should be shown
     this.ShowHeaderLogo = function () {
-        return false;
+        return true;
     }
 
     self.Log = function (message) {


### PR DESCRIPTION
This add a simple func to the appbridge which returns a boolean value indicating if symphony logo should be shown.  This func is queried by the client code at startup.  

Blackrock has requested this feature so that when they customize wrapper's title bar, they can hide the symphony header logo as it becomes redundant.
