### PR TITLE
DES-9287: fix initArgs

### DIFF
--- a/minuet/Paragon.Runtime/EventArgs/RenderProcessInitEventArgs.cs
+++ b/minuet/Paragon.Runtime/EventArgs/RenderProcessInitEventArgs.cs
@@ -64,10 +64,12 @@ namespace Paragon.Runtime
                     if (disposing)
                     {
                         if (_initArgs != null)
+                        {
                             _initArgs.Dispose();
+                            _initArgs = null;
+                        }
                     }
 
-                    _initArgs = null;
                     _disposed = true;
                 }    
             }


### PR DESCRIPTION
in ticket DES-9287 we got the exception below... we didn't get full logs, so speculating that fix here might help.  with previous code it is possible that initArgs never gets disposed.
