### PR TITLE
DES-10375: add option to enable-media-stream

### DIFF
--- a/minuet/Paragon.Extensibility/IApplicationManifest.cs
+++ b/minuet/Paragon.Extensibility/IApplicationManifest.cs
@@ -77,6 +77,12 @@ namespace Paragon.Plugins
         string[] CustomProtocolWhitelist { get; set; }
 
         bool DisableSpellChecking { get; set; }
+        
+        /// <summary>
+        /// if true passes command line --media-stream-enable to chromium - 
+        /// needed to enable screen sharing over webrtc
+        /// </summary>
+        bool EnableMediaStream { get; set; }
 
         string BrowserLanguage { get; set; }
 

--- a/minuet/Paragon.Runtime/CefBrowserApplication.cs
+++ b/minuet/Paragon.Runtime/CefBrowserApplication.cs
@@ -27,16 +27,26 @@ namespace Paragon.Runtime
         public event EventHandler<RenderProcessInitEventArgs> RenderProcessInitialize;
         private readonly bool _disableSpellChecking = false;
         private readonly string _spellCheckLanguage = string.Empty;
+        private readonly bool _enableMediaStream = false;
 
         public CefBrowserApplication()
-            : this(false, string.Empty)
+            : this(false, string.Empty, false)
         {
         }
 
-        public CefBrowserApplication(bool disableSpellChecking, string spellCheckLanguage)
+        public CefBrowserApplication(bool disableSpellChecking, string spellCheckLanguage, bool enableMediaStream)
         {
             _disableSpellChecking = disableSpellChecking;
             _spellCheckLanguage = spellCheckLanguage;
+            _enableMediaStream = enableMediaStream;
+        }
+
+        protected override void OnBeforeCommandLineProcessing(string processType, CefCommandLine commandLine)
+        {
+            if (_enableMediaStream)
+                commandLine.AppendSwitch("--enable-media-stream");
+
+            base.OnBeforeCommandLineProcessing(processType, commandLine);
         }
 
         protected override CefBrowserProcessHandler GetBrowserProcessHandler()

--- a/minuet/Paragon.Runtime/Kernel/Applications/ApplicationManager.cs
+++ b/minuet/Paragon.Runtime/Kernel/Applications/ApplicationManager.cs
@@ -126,6 +126,8 @@ namespace Paragon.Runtime.Kernel.Applications
         /// Indicates whether spell checking is enabled.
         /// </summary>
         public bool DisableSpellChecking { get; private set; }
+
+        public bool EnableMediaStream { get; private set; }
         
         /// <summary>
         /// All the running paragon applications
@@ -243,6 +245,7 @@ namespace Paragon.Runtime.Kernel.Applications
             CacheFolder = Path.Combine(_paragonFolder, string.IsNullOrEmpty(manifest.ProcessGroup) ? manifest.Id : manifest.ProcessGroup);
             Environment = metadata.Environment;
             DisableSpellChecking = manifest.DisableSpellChecking;
+            EnableMediaStream = manifest.EnableMediaStream;
 
             // set browser language from manifest - default is en-US
             // "automatic" will set browser language to os culture info
@@ -292,6 +295,7 @@ namespace Paragon.Runtime.Kernel.Applications
                     auth_server_whitelist,
                     auth_delegate_whitelist,
                     DisableSpellChecking,
+                    EnableMediaStream,
                     Environment == ApplicationEnvironment.Development);
             }
 

--- a/minuet/Paragon.Runtime/PackagedApplication/ApplicationManifest.cs
+++ b/minuet/Paragon.Runtime/PackagedApplication/ApplicationManifest.cs
@@ -153,6 +153,8 @@ namespace Paragon.Runtime.PackagedApplication
 
         public bool DisableSpellChecking { get; set; }
 
+        public bool EnableMediaStream { get; set; }
+
         public string BrowserLanguage { get; set; }
 
         public string CustomTheme { get; set; }

--- a/minuet/Paragon.Runtime/ParagonRuntime.cs
+++ b/minuet/Paragon.Runtime/ParagonRuntime.cs
@@ -65,6 +65,7 @@ namespace Paragon.Runtime
                                       string authserverlist = null,
                                       string authdelgatelist = null,
                                       bool disableSpellChecking = false,
+                                      bool enableMediaStream = false,
                                       bool ignoreCertificateErrors = false,
                                       bool persistSessionCookies = false)
         {
@@ -154,7 +155,7 @@ namespace Paragon.Runtime
                     Logger.Info("Passing Args to CefApp: " + argString);
                     var args = new CefMainArgs(appArgs.ToArray());
 
-                    _cefApp = new CefBrowserApplication(disableSpellChecking, browserLanguage);
+                    _cefApp = new CefBrowserApplication(disableSpellChecking, browserLanguage, enableMediaStream);
                     _cefApp.RenderProcessInitialize += OnRenderProcessInitialize;
                     
                     if (BeforeCefInitialize != null)


### PR DESCRIPTION
add option in manifest that can enable chromium command line paramter: --enable-media-stream

if value in manifest is not provided or false then command line parameter is not set
if value in manifest is true then command line parameter --enable-media-stream is set

this parameter is needed for screen sharing/webrtc feature.
