### PR TITLE
Fix pgx file creation

### DIFF
--- a/minuet/Paragon.AppPackager/ParagonPackageSigner.cs
+++ b/minuet/Paragon.AppPackager/ParagonPackageSigner.cs
@@ -36,7 +36,7 @@ namespace Paragon.AppPackager
             if (certificate == null)
                 throw new Exception("certificate");
 
-            using (Package signedPackage = Package.Open(outputPath, FileMode.Create))
+            using (Package signedPackage = Package.Open(outputPath, FileMode.CreateNew))
             {
                 var uriString = "/" + InnerPackageName + ".pgx";
                 var uri = new Uri(uriString, UriKind.Relative);


### PR DESCRIPTION
PGX open should be done with parameter .CreateNew, in order to replace existing file.
