### PR TITLE
Create Dump files & zip them with log files

### DIFF
--- a/minuet/Paragon.Runtime/Win32/MemoryDump.cs
+++ b/minuet/Paragon.Runtime/Win32/MemoryDump.cs
@@ -15,14 +15,13 @@
 //specific language governing permissions and limitations
 //under the License.
 
-using System.Linq;
-using System.Text;
 using Paragon.Plugins;
 using Paragon.Runtime.Desktop;
 using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Diagnostics;
 
 namespace Paragon.Runtime.Win32
 {
@@ -89,6 +88,27 @@ namespace Paragon.Runtime.Win32
             }
 
             return success;
+        }
+
+        public static void MiniDumpToFile(String fileToDump, Process process)
+        {
+            FileStream fsToDump = null;
+            if (File.Exists(fileToDump))
+                fsToDump = File.Open(fileToDump, FileMode.Append);
+            else
+                fsToDump = File.Create(fileToDump);
+
+            try
+            {
+                NativeMethods.MiniDumpWriteDump(process.Handle, process.Id,
+                    fsToDump.SafeFileHandle.DangerousGetHandle(), NativeMethods.MINIDUMP_TYPE.MiniDumpNormal,
+                    IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                fsToDump.Close();
+            }
+            catch (Exception ex)
+            {
+                throw (ex);
+            }
         }
     }
 }

--- a/minuet/Paragon.Runtime/Win32/NativeMethods.cs
+++ b/minuet/Paragon.Runtime/Win32/NativeMethods.cs
@@ -31,6 +31,27 @@ namespace Paragon.Runtime.Win32
     {
         public const int LOGPIXELSX = 88;
 
+        internal enum MINIDUMP_TYPE
+        {
+            MiniDumpNormal = 0x00000000,
+            MiniDumpWithDataSegs = 0x00000001,
+            MiniDumpWithFullMemory = 0x00000002,
+            MiniDumpWithHandleData = 0x00000004,
+            MiniDumpFilterMemory = 0x00000008,
+            MiniDumpScanMemory = 0x00000010,
+            MiniDumpWithUnloadedModules = 0x00000020,
+            MiniDumpWithIndirectlyReferencedMemory = 0x00000040,
+            MiniDumpFilterModulePaths = 0x00000080,
+            MiniDumpWithProcessThreadData = 0x00000100,
+            MiniDumpWithPrivateReadWriteMemory = 0x00000200,
+            MiniDumpWithoutOptionalData = 0x00000400,
+            MiniDumpWithFullMemoryInfo = 0x00000800,
+            MiniDumpWithThreadInfo = 0x00001000,
+            MiniDumpWithCodeSegs = 0x00002000
+        }
+        [DllImport("dbghelp.dll")]
+        public static extern bool MiniDumpWriteDump(IntPtr hProcess,Int32 ProcessId,IntPtr hFile,MINIDUMP_TYPE DumpType,IntPtr ExceptionParam,IntPtr UserStreamParam,IntPtr CallackParam);
+
         [DllImport("user32.dll")]
         public static extern IntPtr CallNextHookEx(IntPtr hhook, int code, IntPtr wParam, IntPtr lParam);
 

--- a/minuet/Paragon/Program.cs
+++ b/minuet/Paragon/Program.cs
@@ -25,11 +25,69 @@ using Paragon.Plugins;
 using Paragon.Properties;
 using Paragon.Runtime;
 using Paragon.Runtime.Kernel.Applications;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using System.IO.Packaging;
+using System.Text;
 
 namespace Paragon
 {
     static class Program
     {
+        public class Dump
+        {        
+            internal enum MINIDUMP_TYPE
+            {
+                MiniDumpNormal = 0x00000000,
+                MiniDumpWithDataSegs = 0x00000001,
+                MiniDumpWithFullMemory = 0x00000002,
+                MiniDumpWithHandleData = 0x00000004,
+                MiniDumpFilterMemory = 0x00000008,
+                MiniDumpScanMemory = 0x00000010,
+                MiniDumpWithUnloadedModules = 0x00000020,
+                MiniDumpWithIndirectlyReferencedMemory = 0x00000040,
+                MiniDumpFilterModulePaths = 0x00000080,
+                MiniDumpWithProcessThreadData = 0x00000100,
+                MiniDumpWithPrivateReadWriteMemory = 0x00000200,
+                MiniDumpWithoutOptionalData = 0x00000400,
+                MiniDumpWithFullMemoryInfo = 0x00000800,
+                MiniDumpWithThreadInfo = 0x00001000,
+                MiniDumpWithCodeSegs = 0x00002000
+            }
+            [DllImport("dbghelp.dll" )]
+            static extern bool MiniDumpWriteDump (
+                IntPtr hProcess,
+                Int32 ProcessId,
+                IntPtr hFile,
+                MINIDUMP_TYPE DumpType,
+                IntPtr ExceptionParam,
+                IntPtr UserStreamParam,
+                IntPtr CallackParam );
+
+            public static void MiniDumpToFile ( String fileToDump, string processToDump )
+            {
+                FileStream fsToDump = null;
+                if ( File.Exists( fileToDump ) )
+                    fsToDump = File.Open( fileToDump, FileMode.Append );
+                else
+                    fsToDump = File.Create( fileToDump );
+
+                try
+                {
+                    Process process = Process.GetProcessesByName(processToDump).First();
+
+                    MiniDumpWriteDump(process.Handle, process.Id,
+                        fsToDump.SafeFileHandle.DangerousGetHandle(), MINIDUMP_TYPE.MiniDumpNormal,
+                        IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                    fsToDump.Close();
+                }
+                catch (Exception ex)
+                {
+                    throw (ex);
+                }
+            }
+        };
+        
         private static ApplicationManager _appManager;
 
         [STAThread]
@@ -128,12 +186,142 @@ namespace Paragon
             }
         }
 
+        private static Dictionary<string, string> _contentTypesGiven = new Dictionary<string, string>();
+
+        private static Uri GetRelativeUri(string currentFile)
+        {
+            var uriString = currentFile;
+            if (!uriString.StartsWith("\\"))
+            {
+                uriString = "\\" + uriString;
+            }
+
+            var relPath = uriString.Substring(
+                uriString.IndexOf('\\')).Replace('\\', '/').Replace(' ', '_');
+
+            var normalized = relPath.Normalize(NormalizationForm.FormKD);
+
+            var removal = Encoding.GetEncoding(
+                Encoding.ASCII.CodePage,
+                new EncoderReplacementFallback(string.Empty),
+                new DecoderReplacementFallback(string.Empty));
+
+            var bytes = removal.GetBytes(normalized);
+            var uri = Encoding.ASCII.GetString(bytes);
+            return new Uri(uri, UriKind.Relative);
+        }
+
+
+        public static void CopyStream(Stream input, Stream output)
+        {
+            byte[] buffer = new byte[32768];
+            int read;
+            while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                output.Write (buffer, 0, read);
+            }
+        }
+
+        private static void AddFilesToZip(string zipFilename, string[] filesToAdd, CompressionOption compression = CompressionOption.Maximum)
+        {
+            using (var memStream = new MemoryStream())
+            {
+                using (Package zip = System.IO.Packaging.Package.Open(memStream, FileMode.OpenOrCreate))
+                {
+                    foreach (string fileToAdd in filesToAdd)
+                    {
+                        //skip zip files.
+                        if (fileToAdd.EndsWith(".zip"))
+                            continue;
+
+                        string destFilename = ".\\" + Path.GetFileName(fileToAdd);
+                        Uri uri = PackUriHelper.CreatePartUri(new Uri(destFilename, UriKind.Relative));
+                        if (zip.PartExists(uri))
+                        {
+                            zip.DeletePart(uri);
+                        }
+                        PackagePart part = zip.CreatePart(uri, "", compression);
+                        try
+                        {
+                            using (FileStream fileStream = new FileStream(fileToAdd, FileMode.Open, FileAccess.Read))
+                            {
+                                using (Stream dest = part.GetStream())
+                                {
+                                    CopyStream(fileStream, part.GetStream());
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            throw (ex);
+                        }
+                    }
+                    using (FileStream zipfilestream = new FileStream(zipFilename, FileMode.Create, FileAccess.Write))
+                    {
+                        memStream.Position = 0;
+                        CopyStream(memStream, zipfilestream);
+                    }
+                }
+            }
+        }              
+
         private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
             var logger = ParagonLogManager.GetLogger();
             logger.Error(string.Format("An unhandled domain exception has occurred: {0}", e.ExceptionObject ?? string.Empty));
-
+            
             var errMessage = "A fatal error has occurred.";
+
+            try
+            {
+                String dstDiretory = ParagonLogManager.LogDirectory;
+                String fileName = "dump-file-" + DateTime.Now.ToString("dd_MM_yyyy_HH-mm-ss-fff") + ".zip";
+                String fullPath = Path.Combine(dstDiretory, fileName);
+
+                //Dump apps.
+                //This is not ok. Somehow, current available code to dump running apss is not ok.
+                //WebApplication runningApp = (WebApplication)_appManager.AllApplicaions.FirstOrDefault();
+                //Paragon.Runtime.Win32.MemoryDump.CreateMemoryDump((AppInfo)runningApp.GetRunningApps().FirstOrDefault(), Runtime.Win32.ProcessDumpType.MiniDumpWithFullMemory);
+
+                //Dump paragon.exe.
+                String fileToDump = Path.Combine(dstDiretory, "paragon.exe.dmp");
+                Program.Dump.MiniDumpToFile(fileToDump, "Paragon");
+
+                //Dump Paragon.Renderer.
+                fileToDump = Path.Combine(dstDiretory, "Paragon.Renderer.exe.dmp");
+                Program.Dump.MiniDumpToFile(fileToDump, "Paragon.Renderer");
+
+                String packagePath = Path.Combine(dstDiretory, "package");
+                
+                //delete temp directory. Ensure cleanup.
+                if (System.IO.Directory.Exists(packagePath))
+                    System.IO.Directory.Delete(packagePath, true);
+
+                //Create temp directory
+                System.IO.Directory.CreateDirectory(packagePath);
+
+                //Copy files to temp directory to avoid denied access to files with open handler.
+                string[] fileEntries = Directory.GetFiles(dstDiretory);
+                System.Collections.Generic.List<string> files = fileEntries.ToList();
+                foreach (string file in fileEntries)
+                {
+                    if (!file.EndsWith(".zip"))
+                    {
+                        File.Copy(file, Path.Combine(packagePath, Path.GetFileName(file)));
+                    }
+                }
+
+                //Zip files.
+                fileEntries = Directory.GetFiles(packagePath);
+                AddFilesToZip(fullPath, fileEntries);
+
+                errMessage += string.Format("\n\nLog files and application dump files are zipped in:\n{0}.", fullPath);
+            }
+            catch (Exception ex)
+            {
+                logger.Error(string.Format("Failed to collect log files & dump running apps: {0}", e.ExceptionObject ?? string.Empty));
+            }
+
             if (_appManager != null && _appManager.AllApplicaions != null)
             {
                 var apps = _appManager.AllApplicaions.Select(app => app.Name).ToArray();


### PR DESCRIPTION
Existing Paragon.Runtime.Win32.MemoryDump.CreateMemoryDump method fails. It seems that AppInfo fetch with (AppInfo)runningApp.GetRunningApps().FirstOrDefault() is not valid.
