### PR TITLE
DES-10788: fix crash and thrown exception

### DIFF
--- a/minuet/Paragon.Runtime/Plugins/BrowserSideMessageRouter.cs
+++ b/minuet/Paragon.Runtime/Plugins/BrowserSideMessageRouter.cs
@@ -186,6 +186,11 @@ namespace Paragon.Runtime.Plugins
                 return;
             }
 
+            if (!handler.IsValid)
+            {
+                return;
+            }
+
             switch (pluginMessage.MessageType)
             {
                 case PluginMessageType.FunctionInvoke:

--- a/minuet/Paragon.Runtime/WPF/AutoSaveWindowPositionBehavior.cs
+++ b/minuet/Paragon.Runtime/WPF/AutoSaveWindowPositionBehavior.cs
@@ -82,9 +82,12 @@ namespace Paragon.Runtime.WPF
 
             try
             {
-                AssociatedObject.LocationChanged -= OnSizeOrLocationChanged;
-                AssociatedObject.SizeChanged -= OnSizeOrLocationChanged;
-                AssociatedObject.Activated -= OnActivated;
+                if (AssociatedObject != null)
+                {
+                    AssociatedObject.LocationChanged -= OnSizeOrLocationChanged;
+                    AssociatedObject.SizeChanged -= OnSizeOrLocationChanged;
+                    AssociatedObject.Activated -= OnActivated;
+                }
                 SystemEvents.SessionSwitch -= OnSessionSwitch;
                 SystemEvents.DisplaySettingsChanged -= OnDisplaySettingsChanged;
             }


### PR DESCRIPTION
fix for crash reported in DES-11972.  handler was already disposed.  checking isValid will return early if already disposed.

also add safety check...fix exception seen when AssociatedObject is null.
