### PR TITLE
DES-12844: Fix get default download path method

### DIFF
--- a/minuet/Paragon.Runtime/Kernel/Windowing/ApplicationWindow.cs
+++ b/minuet/Paragon.Runtime/Kernel/Windowing/ApplicationWindow.cs
@@ -1210,11 +1210,22 @@ namespace Paragon.Runtime.Kernel.Windowing
         string getDownLoadFullPath(string fileName)
         {
 
-            string pathUser = Environment.ExpandEnvironmentVariables("%HOMEDRIVE%%HOMEPATH%");
-            string pathDownload = Path.Combine(pathUser, "Downloads");
+            string pathDownload = null;
 
-            // fall back to a temp file if directory doesn't exist or doesn't have write permissions
-            if (!System.IO.Directory.Exists(pathDownload) || !hasDirWritePerms(pathDownload))
+
+            IntPtr outPath;
+            String DownloadFolderGuid = "{374DE290-123F-4565-9164-39C4925E467B}";
+            Boolean defaultUser = false;
+            
+            int result = NativeMethods.SHGetKnownFolderPath(new Guid(DownloadFolderGuid),
+                (uint)NativeMethods.KnownFolderFlags.DontVerify, new IntPtr(defaultUser ? -1 : 0), out outPath);
+            
+            if (result >= 0)
+            {
+                pathDownload = Marshal.PtrToStringUni(outPath);
+            }
+
+            if (String.IsNullOrEmpty(pathDownload) || !System.IO.Directory.Exists(pathDownload) || !hasDirWritePerms(pathDownload))
             {
                 string newfileName = Path.GetTempFileName();
                 string newFullPath = System.IO.Path.ChangeExtension(newfileName, System.IO.Path.GetExtension(fileName));

--- a/minuet/Paragon.Runtime/Win32/NativeMethods.cs
+++ b/minuet/Paragon.Runtime/Win32/NativeMethods.cs
@@ -310,5 +310,25 @@ namespace Paragon.Runtime.Win32
 
         [DllImport("clrdump.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern Int32 CreateDump(Int32 processId, string fileName, Int32 dumpType, Int32 excThreadId, IntPtr extPtrs);
+
+        [DllImport("Shell32.dll")]
+        public static extern int SHGetKnownFolderPath(
+            [MarshalAs(UnmanagedType.LPStruct)]Guid rfid, uint dwFlags, IntPtr hToken,
+            out IntPtr ppszPath);
+
+        [Flags]
+        public enum KnownFolderFlags : uint
+        {
+            SimpleIDList = 0x00000100,
+            NotParentRelative = 0x00000200,
+            DefaultPath = 0x00000400,
+            Init = 0x00000800,
+            NoAlias = 0x00001000,
+            DontUnexpand = 0x00002000,
+            DontVerify = 0x00004000,
+            Create = 0x00008000,
+            NoAppcontainerRedirection = 0x00010000,
+            AliasOnly = 0x80000000
+        }
     }
 }


### PR DESCRIPTION
Implementing new get default download path using WinAPI SHGetKnownFolderPath method.
Solution proposed in this URL:
http://stackoverflow.com/questions/10667012/getting-downloads-folder-in-c
