### PR TITLE
DES-11972 [Save Layout] Save layout wrapper crashes

### DIFF
--- a/minuet/Paragon.Runtime/ICefWebBrowser.cs
+++ b/minuet/Paragon.Runtime/ICefWebBrowser.cs
@@ -214,5 +214,11 @@ namespace Paragon.Runtime
 
         // if supplied this (not null) this is the initial placement of the window
         Paragon.Runtime.Win32.RECT? initialWindowPlacement { get; }
+
+        /// <summary>
+        /// Sends a kill message to renderer process
+        /// </summary>
+        /// <param name="set"></param>
+        void SendKillRenderer();
     }
 }

--- a/minuet/Paragon.Runtime/Kernel/Windowing/ApplicationWindow.cs
+++ b/minuet/Paragon.Runtime/Kernel/Windowing/ApplicationWindow.cs
@@ -31,6 +31,7 @@ using Paragon.Plugins;
 using Paragon.Runtime.Annotations;
 using Paragon.Runtime.Desktop;
 using Paragon.Runtime.Kernel.HotKeys;
+using Paragon.Runtime.Kernel.Applications;
 using Paragon.Runtime.Win32;
 using Paragon.Runtime.WinForms;
 using Paragon.Runtime.WPF;
@@ -549,7 +550,9 @@ namespace Paragon.Runtime.Kernel.Windowing
         [JavaScriptPluginMember(Name = "refresh")]
         public void RefreshWindow(bool ignoreCache = true)
         {
-            DispatchIfRequired(() => _browser.Reload(ignoreCache), true);
+            // Refreshing should restart this app, let weapplication know about it.
+            WebApplication runningApp = (WebApplication)ApplicationManager.GetInstance().AllApplicaions.FirstOrDefault();
+            runningApp.Refresh();
         }
 
         [JavaScriptPluginMember(Name = "executeJavaScript")]
@@ -1593,7 +1596,7 @@ namespace Paragon.Runtime.Kernel.Windowing
 
         private void Reload(bool ignoreCache)
         {
-            _browser.Reload(ignoreCache);
+            RefreshWindow(ignoreCache);
         }
 
         private void ShowPopup(object sender, ShowPopupEventArgs eventArgs)

--- a/minuet/Paragon.Runtime/Kernel/Windowing/ApplicationWindowManager.cs
+++ b/minuet/Paragon.Runtime/Kernel/Windowing/ApplicationWindowManager.cs
@@ -71,6 +71,9 @@ namespace Paragon.Runtime.Kernel.Windowing
             Application = application;
             CreateNewApplicationWindow = createNewWindow;
             _getRootBrowser = getRootBrowser;
+
+            // Updating the _getRootBrowser pointer clear _rootBrowser so it gets updated.
+            _rootBrowser = null; 
         }
 
         public virtual void CreateWindow(CreateWindowRequest request)

--- a/minuet/Paragon.Runtime/PackagedApplication/ApplicationManifest.cs
+++ b/minuet/Paragon.Runtime/PackagedApplication/ApplicationManifest.cs
@@ -238,7 +238,7 @@ namespace Paragon.Runtime.PackagedApplication
     {
         public AppInfo()
         {
-            StartupTimeout = 10;
+            StartupTimeout = System.Diagnostics.Debugger.IsAttached ? 1000 : 10;
         }
 
         /// <summary>

--- a/minuet/Paragon.Runtime/Plugins/BrowserSideMessageRouter.cs
+++ b/minuet/Paragon.Runtime/Plugins/BrowserSideMessageRouter.cs
@@ -370,6 +370,23 @@ namespace Paragon.Runtime.Plugins
         }
 
         /// <summary>
+        /// Sends a message to renderer so we can kill the renderer.
+        /// Can be called on any thread as the CEF API involved (<see cref="CefBrowser.SendProcessMessage"/>) can be called on any thread when in the browser process.
+        /// </summary>
+        /// <param name="browser">
+        /// The browser to send the response to.
+        /// </param>
+        public void SendKillRenderer(CefBrowser browser)
+        {
+            var responseMessage = new PluginMessage
+            {
+                MessageType = PluginMessageType.KillRenderer
+            };
+
+            SendMessage(browser, responseMessage);
+        }
+
+        /// <summary>
         /// Send a response to a function call, which can include the call being cancelled.
         /// Can be called on any thread as the CEF API involved (<see cref="CefBrowser.SendProcessMessage"/>) can be called on any thread when in the browser process.
         /// </summary>

--- a/minuet/Paragon.Runtime/Plugins/IBrowserSideMessageRouter.cs
+++ b/minuet/Paragon.Runtime/Plugins/IBrowserSideMessageRouter.cs
@@ -23,5 +23,6 @@ namespace Paragon.Runtime.Plugins
     {
         IPluginManager PluginManager { get; }
         CefListValue CreatePluginInitMessage();
+        void SendKillRenderer(CefBrowser browser);
     }
 }

--- a/minuet/Paragon.Runtime/Plugins/MessageRouter.cs
+++ b/minuet/Paragon.Runtime/Plugins/MessageRouter.cs
@@ -50,7 +50,7 @@ namespace Paragon.Runtime.Plugins
                     Data = args.GetString(4), 
                     BrowserId = args.GetInt(5), 
                     ContextId = args.GetInt(6), 
-                    FrameId = (args.GetInt(8) << 32) | ((long) (args.GetInt(7))), 
+                    FrameId = (long) ((ulong) (args.GetInt(8) << 32) | ((ulong) (args.GetInt(7)))), 
                     V8CallbackId = new Guid(args.GetString(9))
                 };
 
@@ -91,7 +91,7 @@ namespace Paragon.Runtime.Plugins
                 Data = args.GetString(4),
                 BrowserId = args.GetInt(5),
                 ContextId = args.GetInt(6),
-                FrameId = (args.GetInt(8) << 32) | ((long) (args.GetInt(7))),
+                FrameId = (long) ((ulong) (args.GetInt(8) << 32) | (( ulong) (args.GetInt(7)))),
                 V8CallbackId = new Guid(args.GetString(9))
             };
         }

--- a/minuet/Paragon.Runtime/Plugins/PluginMessageType.cs
+++ b/minuet/Paragon.Runtime/Plugins/PluginMessageType.cs
@@ -68,5 +68,10 @@ namespace Paragon.Runtime.Plugins
         /// Remove a retained callback or listener
         /// </summary>
         RemoveRetained = 256,
+
+        /// <summary>
+        /// Kill the Renderer process so we can start cleanly
+        /// </summary>
+        KillRenderer = 512,
     }
 }

--- a/minuet/Paragon.Runtime/Plugins/RenderSideMessageRouter.cs
+++ b/minuet/Paragon.Runtime/Plugins/RenderSideMessageRouter.cs
@@ -485,6 +485,10 @@ namespace Paragon.Runtime.Plugins
                     var payload = ParagonJsonSerializer.Deserialize<ResultData>(pluginMessage.Data);
                     OnBrowserCallbackInvokeReceived(pluginMessage, payload);
                     break;
+                case PluginMessageType.KillRenderer:
+                    // We have been asked to kill ourselves, lets exit the process
+                    System.Environment.Exit(1);
+                    break;
                 case PluginMessageType.RemoveRetained:
                     // Remove a listener in the render process (handles browser side dynamic plugin dispose scenario)
                     var retainedCallback = _pendingCallbacks.Remove(pluginMessage.MessageId);

--- a/minuet/Paragon.Runtime/WPF/CefWebBrowser.cs
+++ b/minuet/Paragon.Runtime/WPF/CefWebBrowser.cs
@@ -153,6 +153,11 @@ namespace Paragon.Runtime.WPF
             }
         }
 
+        public void SendKillRenderer()
+        {
+            _router.SendKillRenderer(_browser);
+        }
+
         public void Close(bool force = false)
         {
             Logger.Info("Closing browser {0}", Identifier);


### PR DESCRIPTION
On Refresh we ask the renderer process to kill itself and restart the
whole thing again. This way the renderer process starts with a memory of 0
and never crosses more than some value.

The real fix is to find leaks and fix them. This would be my step 2.