### PR TITLE
fix cmd line arg for multi-renderer processes

### DIFF
--- a/minuet/Paragon.Runtime/CefBrowserApplication.cs
+++ b/minuet/Paragon.Runtime/CefBrowserApplication.cs
@@ -43,6 +43,9 @@ namespace Paragon.Runtime
 
         protected override void OnBeforeCommandLineProcessing(string processType, CefCommandLine commandLine)
         {
+            // Prevent a separate gpu-process renderer process from being started.
+            commandLine.AppendSwitch("--in-process-gpu");
+            
             if (_enableMediaStream)
                 commandLine.AppendSwitch("--enable-media-stream");
 

--- a/minuet/Paragon.Runtime/CefRenderApplication.cs
+++ b/minuet/Paragon.Runtime/CefRenderApplication.cs
@@ -36,9 +36,6 @@ namespace Paragon.Runtime
 
         protected override void OnBeforeCommandLineProcessing(string processType, CefCommandLine commandLine)
         {
-            // Prevent a separate gpu-process renderer process from being started.
-            commandLine.AppendSwitch("in-process-gpu");
-
             Logger.Info("{0} process started with commandline arguments : {1}",
                 string.IsNullOrEmpty(processType) ? "Browser" : processType, commandLine.ToString());
 


### PR DESCRIPTION
chrome changed how cmd line arg works and now needs to be passed through main process rather than renderer process.