### PR TITLE
remove winhttp-proxy-resolver flag

### DIFF
--- a/minuet/Paragon.Runtime/ParagonRuntime.cs
+++ b/minuet/Paragon.Runtime/ParagonRuntime.cs
@@ -134,9 +134,6 @@ namespace Paragon.Runtime
                     List<string> appArgs = new List<string>();
                     appArgs.Add("--process-per-tab");
 
-                    // as per DES-13210, re-test when chromium 56 is available and see if we can remove this flag
-                    appArgs.Add("--winhttp-proxy-resolver");
-
                     // Pass through Kerberos and proxy parameters.
                     for (int i = 0; i < argArray.Length; i++)
                     {


### PR DESCRIPTION
shouldn't be needed anymore since we have upgraded to chromium 56.